### PR TITLE
Fix cannot execute on open (nix)

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -1041,10 +1041,9 @@ begin
       // Restart the app with the LIBOVERLAY_SCROLLBAR=0 env var.
       proc:=TProcess.Create(nil);
       try
-        s:='';
-        for i:=0 to ParamCount do
-          s:=s + '"' + ParamStrUTF8(i) + '" ';
-        proc.CommandLine:=s;
+        proc.Executable:=ParamStrUTF8(0);
+        for i:=1 to ParamCount do
+		  proc.Parameters.Add(ParamStrUTF8(i));
         for i:=0 to GetEnvironmentVariableCount - 1 do
           proc.Environment.Add(GetEnvironmentString(i));
         proc.Environment.Values['LIBOVERLAY_SCROLLBAR']:='0';

--- a/utils.pas
+++ b/utils.pas
@@ -402,18 +402,21 @@ var
   cmd, fn: String;
 begin
   Result:=-1;
+  WrkProcess:=TProcess.Create(nil);
+  WrkProcess.Options:=[poNoConsole,poWaitOnExit];  
+
   cmd:=FindDefaultExecutablePath('xdg-open');
   if cmd = '' then begin
     cmd:=FindDefaultExecutablePath('gnome-open');
     if cmd = '' then begin
       cmd:=FindDefaultExecutablePath('kioclient');
       if cmd <> '' then
-        cmd:=cmd + ' exec'
+        Wrkprocess.Parameters.Add('exec')
       else begin
         cmd:=FindDefaultExecutablePath('kfmclient');
         if cmd = '' then
           exit;
-        cmd:=cmd + ' exec';
+        Wrkprocess.Parameters.Add('exec')
       end;
     end;
   end;
@@ -421,11 +424,10 @@ begin
   fn:=FileName;
   if Pos('://', fn) > 0 then
     fn:=StringReplace(fn, '#', '%23', [rfReplaceAll]);
+  Wrkprocess.Parameters.Add(fn);
+  WrkProcess.Executable:=cmd;
 
-  WrkProcess:=TProcess.Create(nil);
   try
-    WrkProcess.Options:=[poNoConsole];
-    WrkProcess.CommandLine:=cmd + ' "' + fn + '"';
     WrkProcess.Execute;
     Result:=WrkProcess.ExitStatus;
   finally


### PR DESCRIPTION
This fixes an error message that appears on Linux and possibly other posix systems when Trying to open a mapped directory. A message appears saying "Unable to execute <path>". This fixes it. 
The fix is not mine, but I googlecode is closed and I can't remember the name of the person who posted it.