### PR TITLE
Missing Icon

### DIFF
--- a/transgui.lpr
+++ b/transgui.lpr
@@ -39,9 +39,7 @@ uses
   { you can add units after this }, BaseForm, Main, rpc, AddTorrent, ConnOptions, varlist,
   TorrProps, DaemonOptions, About, IpResolver, download, ColSetup, utils, ResTranslator, AddLink, MoveTorrent, AddTracker, Options;
 
-{$ifdef windows}
 {$R *.res}
-{$endif}
 
 begin
   if not CheckAppParams then exit;


### PR DESCRIPTION
I use transmisson-remote-gui on Arch Linux. A month ago, I manually built v5.6.0, but noticed that the tray icon was "empty": on execution, an icon in the tray was created, and worked successfully, but it did show as an empty square, not showing the png icon.

I have had a look at the code, and it seems that the resource file was only being included when building on Windows systems.

This pull request should re-add the resource file to all builds (at least, on my system, the icon shows again).