### PR TITLE
ssl_openssl_lib.pas: Fixed copy-paste mistake.

### DIFF
--- a/synapse/source/lib/ssl_openssl_lib.pas
+++ b/synapse/source/lib/ssl_openssl_lib.pas
@@ -2097,7 +2097,7 @@ begin
     _SslMethodTLSV11 := nil;
     _SslMethodTLSV12 := nil;
     _SslMethodV23 := nil;
-    _SslMethodV23 := nil;
+    _SslMethodTLS := nil;
     _SslCtxUsePrivateKey := nil;
     _SslCtxUsePrivateKeyASN1 := nil;
     _SslCtxUsePrivateKeyFile := nil;


### PR DESCRIPTION
@PeterDaveHello note about this [here](https://github.com/leonsoft-kras/transmisson-remote-gui/pull/966/commits/9bba34167746ecc0108071f0a5d29dc62ebf1f66#r125749430).